### PR TITLE
Fixing folder name

### DIFF
--- a/lib/build/samsungtv/index.js
+++ b/lib/build/samsungtv/index.js
@@ -42,7 +42,7 @@ function configure (opts) {
   var options = opts.native.platforms.samsungtv
   options.root = opts.native.root
   options.templateSrc = path.join(__dirname, '..', '..', '..', 'templates', 'samsungtv')
-  options.buildDir = path.join(options.root, 'build', 'samsungtv','vigour-native')
+  options.buildDir = path.join(options.root, 'build', 'samsungtv','samsung')
   return(options)
 
 }

--- a/templates/samsungtv/widgetlist.xml
+++ b/templates/samsungtv/widgetlist.xml
@@ -5,7 +5,7 @@
       <title>{{name}}</title>
       <compression size="{{size}}" type="zip"/>
       <description>{{name}}</description>
-      <download>http://{{ip}}/vigour-native.zip</download>
+      <download>http://{{ip}}/samsung.zip</download>
     </widget>
 </list>
 </rsp>


### PR DESCRIPTION
Samsung Tv really cares about the folder name that should be `samsung`
This pull request fixes this name, now it uses `samsung` instead `vigour-native`

The folder structure is now `build/samsungtv/samsung`

@shawninder ^^
