### PR TITLE
iOS chromecast linking problem

### DIFF
--- a/lib/builder/ios/installpods.js
+++ b/lib/builder/ios/installpods.js
@@ -2,12 +2,34 @@
 
 var log = require('npmlog')
 var spawn = require('vigour-spawn')
+var fs = require('vigour-fs');
+var path = require('path');
 
 module.exports = exports = function () {
-  if (this.builds) {
-    log.info('- install pods -')
-    return spawn('pod install', { cwd: this.baseDir })
-  } else {
-    log.info('- skipping install pods -')
-  }
+	if (this.builds) {
+		var baseDir = this.baseDir
+
+		function clearPods() {
+			log.info('- clearing pods directory -')
+			var podsDir = path.join(baseDir, 'Pods')
+			log.info('pods dir:', podsDir)
+			// implementing custom promise wrapper - fs.remove on vigour-fs-promised is broken
+			return new Promise(function (resolve, reject) {
+				fs.remove(podsDir, {
+					disableGlob: true,
+				}, function (err) {
+					err ? reject(err) : resolve()
+				})
+			})
+		}
+
+		function installPods() {
+			log.info('- install pods -')
+			return spawn('pod install', { cwd: baseDir })
+		}
+		
+		return clearPods().then(installPods)
+	} else {
+		log.info('- skipping install pods -')
+	}
 }

--- a/templates/ios/vigour-native/Podfile
+++ b/templates/ios/vigour-native/Podfile
@@ -2,4 +2,4 @@ platform :ios, '9.0'
 
 use_frameworks!
 
-pod 'google-cast-sdk'
+pod 'google-cast-sdk', '2.10.2'

--- a/templates/ios/vigour-native/vigour-native.xcodeproj/project.pbxproj
+++ b/templates/ios/vigour-native/vigour-native.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		4959BE771BF3DE2800F7B310 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4959BE761BF3DE2800F7B310 /* WebKit.framework */; };
 		49D6491E1C66AB9800FCBAE1 /* Open.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D6491D1C66AB9800FCBAE1 /* Open.swift */; };
 		49FD242F1C3DAF5800D192FC /* Chromecast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FD242E1C3DAF5800D192FC /* Chromecast.swift */; };
+		E9B5528F1C88CAE000B8668E /* GoogleCast.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9B5528E1C88CAE000B8668E /* GoogleCast.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -98,6 +99,7 @@
 		7A43D812913C64BEB71BFD67 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		AA4A4AB24BBF8CE2C505D681 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		D8414C2504FED5E5C93D7927 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E9B5528E1C88CAE000B8668E /* GoogleCast.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleCast.framework; path = "Pods/google-cast-sdk/GoogleCastSDK-2.10.2-Release/GoogleCast.framework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -108,6 +110,7 @@
 				49044F481C2967DA008392C5 /* StoreKit.framework in Frameworks */,
 				4905E41A1C14CD26001E4026 /* AVFoundation.framework in Frameworks */,
 				4905E4181C14CD12001E4026 /* CoreTelephony.framework in Frameworks */,
+				E9B5528F1C88CAE000B8668E /* GoogleCast.framework in Frameworks */,
 				492195371BFE821900EB8AF5 /* FBSDKShareKit.framework in Frameworks */,
 				4959BE771BF3DE2800F7B310 /* WebKit.framework in Frameworks */,
 				492195351BFE821900EB8AF5 /* FBSDKCoreKit.framework in Frameworks */,
@@ -234,6 +237,7 @@
 		4959BE751BF3DDF800F7B310 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E9B5528E1C88CAE000B8668E /* GoogleCast.framework */,
 				49044F471C2967DA008392C5 /* StoreKit.framework */,
 				4905E4191C14CD26001E4026 /* AVFoundation.framework */,
 				4905E4171C14CD12001E4026 /* CoreTelephony.framework */,
@@ -592,6 +596,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/vigour-native/Vendor",
 					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/Pods/google-cast-sdk/GoogleCastSDK-2.10.2-Release",
 				);
 				INFOPLIST_FILE = "vigour-native/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -616,6 +621,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/vigour-native/Vendor",
 					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/Pods/google-cast-sdk/GoogleCastSDK-2.10.2-Release",
 				);
 				INFOPLIST_FILE = "vigour-native/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;


### PR DESCRIPTION
Building the iOS app causes a native error due to a linking error with the chromecast framework file. I've fixed the bug by fixating the chromecast framework version so that the linking path is static (and won't cause any future issues with version updates) and changed the pods install build phase to do a clean install just to be on the safe side (pods will be installed form your local cache anyway, so it's a minor delay).
